### PR TITLE
`fold_dir` Correction in `constants.py`

### DIFF
--- a/ethos/tokenize/constants.py
+++ b/ethos/tokenize/constants.py
@@ -38,7 +38,7 @@ class DataProp:
             fold=fold,
             dataset_dir="mimic-iv-2.2_Data",
             id_col="subject_id",
-            fold_dir=f"mimic-iv-2.2",
+            fold_dir=fold.value,
             csv_format="csv.gz",
             module=dataset.value,
         )


### PR DESCRIPTION
This PR addresses a correction for the `fold_dir` variable within `constants.py`. The `fold_dir` parameter is essential for loading data in `base.py`, specifically in cases where `data_path` is constructed as follows: https://github.com/ipolharvard/ethos-paper/blob/ef2742985c50a1c753e3882f4a16521c7636228e/ethos/tokenize/base.py#L97
and
https://github.com/ipolharvard/ethos-paper/blob/ef2742985c50a1c753e3882f4a16521c7636228e/ethos/tokenize/base.py#L109

#### Changes Introduced
- **`fold_dir`** is set as a parameter in `constants.py` to distinguish between training and testing datasets.
- `fold_dir` should accept values of either `train` or `test` to ensure accurate data loading paths based on the intended data split.
